### PR TITLE
Support video + snapchat caption text

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ RNStoryShare.isSnapchatAvailable()
         attributionLink: 'https://myproject.com',
         backgroundAsset: 'data:image/png;base64,iVBO...',
         stickerAsset: 'data:image/png;base64,iVBO...',
+	captionText: 'text exemple',
+	media: "photo" // or "video"
         stickerOptions: {
           height: 900,
           width: 900
@@ -197,4 +199,3 @@ Shares a file or base64 image as background, sticker or both to Snapchat. `stick
 
 ## Roadmap
 - Android file path support
-- Video support

--- a/android/src/main/java/com/jobeso/RNStoryShareFileProvider.java
+++ b/android/src/main/java/com/jobeso/RNStoryShareFileProvider.java
@@ -1,6 +1,6 @@
 package com.jobeso;
 
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 
 public class RNStoryShareFileProvider extends FileProvider {
 }

--- a/android/src/main/java/com/jobeso/RNStoryShareModule.java
+++ b/android/src/main/java/com/jobeso/RNStoryShareModule.java
@@ -5,8 +5,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.support.annotation.Nullable;
-import android.support.v4.content.FileProvider;
+import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
 
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.Promise;

--- a/android/src/main/java/com/jobeso/RNStoryShareModule.java
+++ b/android/src/main/java/com/jobeso/RNStoryShareModule.java
@@ -371,7 +371,7 @@ public class RNStoryShareModule extends ReactContextBaseJavaModule {
       File backgroundFile = null;
       File stickerFile = null;
 
-      if(!type.equals(BASE64) && !type.equals(FILE)){
+      if (!type.equals(BASE64) && !type.equals(FILE)){
         throw new Error(ERROR_TYPE_NOT_SUPPORTED);
       }
 
@@ -379,11 +379,11 @@ public class RNStoryShareModule extends ReactContextBaseJavaModule {
         throw new Error(ERROR_TYPE_NOT_SUPPORTED);
       }
 
-      if(backgroundAsset == null && stickerAsset == null){
+      if (backgroundAsset == null && stickerAsset == null){
         throw new Error("backgroundAsset and stickerAsset are not allowed to both be null.");
       }
 
-      if(backgroundAsset != null){
+      if (backgroundAsset != null){
         if (type.equals(BASE64)){
           backgroundFile = getFileFromBase64String(backgroundAsset);
         } else {
@@ -395,7 +395,7 @@ public class RNStoryShareModule extends ReactContextBaseJavaModule {
         }
       }
 
-      if(stickerAsset != null){
+      if (stickerAsset != null){
         stickerFile = getFileFromBase64String(stickerAsset);
 
         if(stickerFile == null){


### PR DESCRIPTION
This PR enable video on both Instagram and Snapchat, with new param `media`.
It add `captionText` param only available for snapchat to add text on photo/video.
It still not working with file path but only base64 on Android.

New params:
```
media<string>("photo" or "video")
captionText<string>
```

Follow exemple here, for `media` and `captionText` on snapchat.
https://github.com/kperreau/react-native-story-share#share-to-snapchat