### PR TITLE
🚑 Fix build failure due to UIImagePNGRepresentation

### DIFF
--- a/android/src/main/java/com/jobeso/RNStoryShareFileProvider.java
+++ b/android/src/main/java/com/jobeso/RNStoryShareFileProvider.java
@@ -1,6 +1,6 @@
 package com.jobeso;
 
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 
 public class RNStoryShareFileProvider extends FileProvider {
 }

--- a/android/src/main/java/com/jobeso/RNStoryShareModule.java
+++ b/android/src/main/java/com/jobeso/RNStoryShareModule.java
@@ -5,8 +5,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.support.annotation.Nullable;
-import android.support.v4.content.FileProvider;
+import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
 
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.Promise;

--- a/ios/RNStoryShare.podspec
+++ b/ios/RNStoryShare.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
 
 
   s.dependency "React"
-  s.dependency "SnapSDK"
+  s.dependency "SnapSDK/SCSDKCreativeKit"
 
 end

--- a/ios/RNStoryShare.swift
+++ b/ios/RNStoryShare.swift
@@ -102,14 +102,14 @@ class RNStoryShare: NSObject{
                 let decodedData = try Data(contentsOf: backgroundAsset!,
                                            options: NSData.ReadingOptions(rawValue: 0))
                 
-                backgroundData = UIImagePNGRepresentation(UIImage(data: decodedData)!)! as NSData
+                backgroundData = UIImage(data: decodedData)!.pngData()! as NSData
             }
             
             if(stickerAsset != nil){
                 let decodedStickerData = try Data(contentsOf: stickerAsset!,
                                                   options: NSData.ReadingOptions(rawValue: 0))
                 
-                stickerData = UIImagePNGRepresentation(UIImage(data: decodedStickerData)!)! as NSData
+                stickerData = UIImage(data: decodedStickerData)!.pngData()! as NSData
             }
 
             _shareToInstagram(backgroundData,


### PR DESCRIPTION
I was unable to build using React Native 0.63.1, due to a couple of issues.
1. UIImagePNGRepresention issues as explained in the commit comment below.
2. Fixes this issue: 
`
dyld: Library not loaded: @rpath/PINCache.framework/PINCache Referenced from: /Users/.../Library/Developer/CoreSimulator/Devices/A67AEA68-7434-4B77-B259-CEF24F8D2F04/data/Containers/Bundle/Application/B09D6537-A239-4252-8EEE-05B8949C4FC0/Example.app/Frameworks/SCSDKBitmojiKit.framework/SCSDKBitmojiKit Reason: image not found
`

Definitely fixes https://github.com/Jobeso/react-native-story-share/issues/13
as mentioned here:
https://github.com/react-native-community/react-native-share/pull/575#issuecomment-540821396

I'm not 100% sure it will work on other Swift versions, but it definitely works for me. 
Meanwhile, I'm currently my forked in my package.json.

Thanks,
Franz
